### PR TITLE
Move Config and ACL to the top-level module

### DIFF
--- a/cmd/libp2p-relay-daemon/main.go
+++ b/cmd/libp2p-relay-daemon/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
+	relaydaemon "github.com/libp2p/go-libp2p-relay-daemon"
 	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 
@@ -22,11 +23,11 @@ func main() {
 	cfgPath := flag.String("config", "", "json configuration file; empty uses the default configuration")
 	flag.Parse()
 
-	cfg, err := loadConfig(*cfgPath)
+	cfg, err := relaydaemon.LoadConfig(*cfgPath)
 	if err != nil {
 		panic(err)
 	}
-	privk, err := loadIdentity(*idPath)
+	privk, err := relaydaemon.LoadIdentity(*idPath)
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +93,7 @@ func main() {
 	go listenPprof(cfg.Daemon.PprofPort)
 	time.Sleep(10 * time.Millisecond)
 
-	acl, err := NewACL(host, cfg.ACL)
+	acl, err := relaydaemon.NewACL(host, cfg.ACL)
 	if err != nil {
 		panic(err)
 	}

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package main
+package relaydaemon
 
 import (
 	"encoding/json"
@@ -9,6 +9,8 @@ import (
 	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 )
 
+// Config stores the full configuration of the relays, ACLs and other settings
+// that influence behaviour of a relay daemon.
 type Config struct {
 	Network NetworkConfig
 	ConnMgr ConnMgrConfig
@@ -18,37 +20,50 @@ type Config struct {
 	Daemon  DaemonConfig
 }
 
+// DaemonConfig controls settings for the relay-daemon itself.
 type DaemonConfig struct {
 	PprofPort int
 }
 
+// NetworkConfig controls listen and annouce settings for the libp2p host.
 type NetworkConfig struct {
 	ListenAddrs   []string
 	AnnounceAddrs []string
 }
 
+// ConnMgrConfig controls the libp2p connection manager settings.
 type ConnMgrConfig struct {
 	ConnMgrLo    int
 	ConnMgrHi    int
 	ConnMgrGrace time.Duration
 }
 
+// RelayV1Config controls activation of V1 circuits and resouce configuration
+// for them.
 type RelayV1Config struct {
 	Enabled   bool
 	Resources relayv1.Resources
 }
 
+// RelayV2Config controls activation of V2 circuits and resouce configuration
+// for them.
 type RelayV2Config struct {
 	Enabled   bool
 	Resources relayv2.Resources
 }
 
+// ACLConfig provides filtering configuration to allow specific peers or
+// subnets to be fronted by relays. In V2, this specifies the peers/subnets
+// that are able to make reservations on the relay. In V1, this specifies the
+// peers/subnets that can be contacted through the relays.
 type ACLConfig struct {
 	AllowPeers   []string
 	AllowSubnets []string
 }
 
-func defaultConfig() Config {
+// DefaultConfig returns a default relay configuration using default resource
+// settings and no ACLs.
+func DefaultConfig() Config {
 	return Config{
 		Network: NetworkConfig{
 			ListenAddrs: []string{
@@ -77,8 +92,11 @@ func defaultConfig() Config {
 	}
 }
 
-func loadConfig(cfgPath string) (Config, error) {
-	cfg := defaultConfig()
+// LoadConfig reads a relay daemon JSON configuration from the given path.
+// The configuration is first initialized with DefaultConfig, so all unset
+// fields will take defaults from there.
+func LoadConfig(cfgPath string) (Config, error) {
+	cfg := DefaultConfig()
 
 	if cfgPath != "" {
 		cfgFile, err := os.Open(cfgPath)

--- a/identity.go
+++ b/identity.go
@@ -1,4 +1,4 @@
-package main
+package relaydaemon
 
 import (
 	"fmt"
@@ -8,18 +8,21 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 )
 
-func loadIdentity(idPath string) (crypto.PrivKey, error) {
+// LoadIdentity reads a private key from the given path and, if it does not
+// exist, generates a new one.
+func LoadIdentity(idPath string) (crypto.PrivKey, error) {
 	if _, err := os.Stat(idPath); err == nil {
-		return readIdentity(idPath)
+		return ReadIdentity(idPath)
 	} else if os.IsNotExist(err) {
 		fmt.Printf("Generating peer identity in %s\n", idPath)
-		return generateIdentity(idPath)
+		return GenerateIdentity(idPath)
 	} else {
 		return nil, err
 	}
 }
 
-func readIdentity(path string) (crypto.PrivKey, error) {
+// ReadIdentity reads a private key from the given path.
+func ReadIdentity(path string) (crypto.PrivKey, error) {
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -28,7 +31,8 @@ func readIdentity(path string) (crypto.PrivKey, error) {
 	return crypto.UnmarshalPrivateKey(bytes)
 }
 
-func generateIdentity(path string) (crypto.PrivKey, error) {
+// GenerateIdentity writes a new random private key to the given path.
+func GenerateIdentity(path string) (crypto.PrivKey, error) {
 	privk, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I would like to programatically generate relays configurations, however this
is slightly more difficult because, despite being exported types, they are in
the "main" package.

This PR moves them to the top-level directory so that they can be imported from
other modules.

I also took the liberty of documenting things.