### PR TITLE
Allow setting config from command line

### DIFF
--- a/cmd/libp2p-relay-daemon/main.go
+++ b/cmd/libp2p-relay-daemon/main.go
@@ -19,9 +19,12 @@ import (
 func main() {
 	idPath := flag.String("id", "identity", "identity key file path")
 	cfgPath := flag.String("config", "", "json configuration file; empty uses the default configuration")
+	// allows passing in a JSON string rather than a file to provide easier programattic usage
+	cfgStr := flag.String("configString", "", "json string with the configuration; empty uses the default configuration")
+
 	flag.Parse()
 
-	cfg, err := relaydaemon.LoadConfig(*cfgPath)
+	cfg, err := relaydaemon.LoadConfig(*cfgPath, *cfgStr)
 	if err != nil {
 		panic(err)
 	}

--- a/config.go
+++ b/config.go
@@ -92,10 +92,26 @@ func DefaultConfig() Config {
 	}
 }
 
-// LoadConfig reads a relay daemon JSON configuration from the given path.
-// The configuration is first initialized with DefaultConfig, so all unset
-// fields will take defaults from there.
-func LoadConfig(cfgPath string) (Config, error) {
+// LoadConfig reads a relay daemon JSON configuration from the given string
+// or a config file from the given path. The configuration is first initialized
+// with DefaultConfig, so all unset fields will take defaults from there.
+// The config file has higher priority than the config string.
+func LoadConfig(cfgPath, cfgStr string) (Config, error) {
+	cfg := DefaultConfig()
+	err := loadConfigFromString(cfgStr, &cfg)
+	if err != nil {
+		return Config{}, err
+	}
+
+	err = loadConfigFromString(cfgPath, &cfg)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func loadConfigFromPath(cfgPath string) (Config, error) {
 	cfg := DefaultConfig()
 
 	if cfgPath != "" {
@@ -113,4 +129,14 @@ func LoadConfig(cfgPath string) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func loadConfigFromString(config string, cfg *Config) error {
+	if config != "" {
+		err := json.Unmarshal([]byte(config), cfg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Adds a `configString` flag which allows passing in the config as a string rather than a file. This should simplify programmatic usage of the daemon. The config file has higher priority than the configuration string.