### PR TITLE
Add Private Swarm Key Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ The daemon creates and persists an identity in the first run, using `identity` a
 to store the private key for the identity.
 You can specify the identity file path with the `-identity` option.
 
+## Private Swarms
+
+The daemon can be instantiated using a multicodec-encoded V1 Private Swarm Key using the `-swarmkey` argument.
+Simply provide a filepath to the PSK and the daemon will automatically configure itself to use this for connections.
+Note that this limits the daemon to only use PSK-supported protocols, excluding QUIC and WebTransport as options.
+
 ## Configuration
 
 `libp2p-relay-daemon` accepts a `-config` option that specifies its configuration; if omitted it will use

--- a/cmd/libp2p-relay-daemon/main.go
+++ b/cmd/libp2p-relay-daemon/main.go
@@ -43,18 +43,19 @@ func main() {
 		libp2p.UserAgent("relayd/1.0"),
 		libp2p.Identity(privk),
 		libp2p.DisableRelay(),
-		// libp2p.PrivateNetwork(),
 		libp2p.ListenAddrStrings(cfg.Network.ListenAddrs...),
 	)
 
 	// load PSK if applicable
-	psk, fprint, err := relaydaemon.LoadSwarmKey(*pskPath)
-	if err != nil {
-		fmt.Printf("error loading swarm key: %s\n", err.Error())
-	}
-	if psk != nil {
-		fmt.Printf("PSK detected, private identity: %x\n", fprint)
-		opts = append(opts, libp2p.PrivateNetwork(psk))
+	if pskPath != nil {
+		psk, fprint, err := relaydaemon.LoadSwarmKey(*pskPath)
+		if err != nil {
+			fmt.Printf("error loading swarm key: %s\n", err.Error())
+		}
+		if psk != nil {
+			fmt.Printf("PSK detected, private identity: %x\n", fprint)
+			opts = append(opts, libp2p.PrivateNetwork(psk))
+		}
 	}
 
 	if len(cfg.Network.AnnounceAddrs) > 0 {

--- a/cmd/libp2p-relay-daemon/main.go
+++ b/cmd/libp2p-relay-daemon/main.go
@@ -16,16 +16,17 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
+// Define the names of arguments here.
 const (
-	IDName     = "id"
-	ConfigName = "config"
-	PSKName    = "swarmkey"
+	NameID     = "id"
+	NameConfig = "config"
+	NamePSK    = "swarmkey"
 )
 
 func main() {
-	idPath := flag.String(IDName, "identity", "identity key file path")
-	cfgPath := flag.String(ConfigName, "", "json configuration file; empty uses the default configuration")
-	pskPath := flag.String(PSKName, "", "multicodec-encoded v1 private swarm key")
+	idPath := flag.String(NameID, "identity", "identity key file path")
+	cfgPath := flag.String(NameConfig, "", "json configuration file; empty uses the default configuration")
+	pskPath := flag.String(NamePSK, "", "file path to a multicodec-encoded v1 private swarm key")
 	flag.Parse()
 
 	cfg, err := relaydaemon.LoadConfig(*cfgPath)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/libp2p/go-libp2p v0.24.0
 	github.com/multiformats/go-multiaddr v0.8.0
+	golang.org/x/crypto v0.3.0
 )
 
 require (
@@ -82,7 +83,6 @@ require (
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.3.0 // indirect

--- a/identity.go
+++ b/identity.go
@@ -1,10 +1,14 @@
 package relaydaemon
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/pnet"
+	"golang.org/x/crypto/salsa20"
+	"golang.org/x/crypto/sha3"
 )
 
 // LoadIdentity reads a private key from the given path and, if it does not
@@ -45,4 +49,46 @@ func GenerateIdentity(path string) (crypto.PrivKey, error) {
 	err = os.WriteFile(path, bytes, 0400)
 
 	return privk, err
+}
+
+// PNet fingerprint section is taken from github.com/ipfs/kubo/core/node/libp2p/pnet.go
+// since the functions in that package were not exported.
+// https://github.com/ipfs/kubo/blob/255e64e49e837afce534555f3451e2cffe9f0dcb/core/node/libp2p/pnet.go#L74
+
+type PNetFingerprint []byte
+
+// PNetFingerprint returns the given swarm key's fingerprint.
+func pnetFingerprint(psk pnet.PSK) []byte {
+	var pskArr [32]byte
+	copy(pskArr[:], psk)
+
+	enc := make([]byte, 64)
+	zeros := make([]byte, 64)
+	out := make([]byte, 16)
+
+	// We encrypt data first so we don't feed PSK to hash function.
+	// Salsa20 function is not reversible thus increasing our security margin.
+	salsa20.XORKeyStream(enc, zeros, []byte("finprint"), &pskArr)
+
+	// Then do Shake-128 hash to reduce its length.
+	// This way if for some reason Shake is broken and Salsa20 preimage is possible,
+	// attacker has only half of the bytes necessary to recreate psk.
+	sha3.ShakeSum128(out, enc)
+
+	return out
+}
+
+// LoadSwarmKey loads a swarm key at the given filepath and decodes it as a PSKv1.
+func LoadSwarmKey(path string) (pnet.PSK, PNetFingerprint, error) {
+	pskBytes, err := os.ReadFile(path)
+	if err != nil || pskBytes == nil {
+		return nil, nil, err
+	}
+
+	psk, err := pnet.DecodeV1PSK(bytes.NewReader(pskBytes))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return psk, pnetFingerprint(psk), nil
 }


### PR DESCRIPTION
This PR follows the release of go-libp2p v0.24.0 by now providing a `-swarmkey` argument which allows users to supply a multicodec-encoded v1 PSK when launching their relay daemon.

Closes #16 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>