### PR TITLE
Added unofficial Ubuntu PPA installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If your installation path differs, you should adjust them accordingly.
 
 The daemon creates and persists an identity in the first run, using `identity` as the file
 to store the private key for the identity.
-You can specify the identity file path with the `-identity` option.
+You can specify the identity file path with the `-id` option.
 
 ### Private Swarms
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 for both protocol versions [v1](https://github.com/libp2p/specs/blob/master/relay/circuit-v1.md) and [v2](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md).
 
 - [Installation](#installation)
-  - [Running as a systemd service](#running-as-a-systemd-service)
-- [Identity](#identity)
+  - [Source](#from-source)
+  - [Unofficial Ubuntu PPA](#unofficial-ubuntu-ppa)
+  - [Development Builds](#development-builds)
+- [Identity file](#identity-file)
 - [Configuration](#configuration)
   - [Minimal config file](#minimal-config-file)
   - [All configuration options](#all-configuration-options)
 - [Release process](#release-process)
 
 ## Installation
+
+### From Source
 
 To install the latest release:
 
@@ -48,7 +52,7 @@ where `<<DISTRO>>` is the codename of your Ubuntu distribution (for example, `ja
 
 The development of the Debian packaging pipeline lives in the [dedicated Github repository](https://github.com/twdragon/ipfs-debian-pkg).
 
-### Development
+### Development Builds
 
 To build from local sources:
 
@@ -58,13 +62,13 @@ cd go-libp2p-relay-daemon
 go install ./...
 ```
 
-### Running as a systemd service
+## Running as a standalone systemd service
 
-There is a service file and an associated launch script in `etc`.
-These two assume that you have installed as root [in your container].
-If your installation path differs, adjust accordingly.
+There is a service file and an associated launch script in [`etc`](./etc) subdirectory.
+These two scripts assume that you have installed as root [in your container].
+If your installation path differs, you should adjust them accordingly.
 
-## Identity
+## Identity File
 
 The daemon creates and persists an identity in the first run, using `identity` as the file
 to store the private key for the identity.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ exit
 sudo apt update
 sudo apt install libp2p-relay
 ```
-where `<<DISTRO>>` is the codename of your Ubuntu distribution (for example, `jammy` for 22.04 LTS). During the first installation the package maintenance script may automatically ask you about which networking profile, CPU accounting model, and/or existing node configuration file you want to use.
+where `<<DISTRO>>` is the codename of your Ubuntu distribution (for example, `jammy` for 22.04 LTS).
 
 **NOTE**: this method also may work with any compatible Debian-based distro which has `libc6` inside, `systemd`, and APT as a package manager.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ go install github.com/libp2p/go-libp2p-relay-daemon/cmd/libp2p-relay-daemon@late
 
 The above will install `libp2p-relay-daemon` binary in `GOBIN` which defaults to `$GOPATH/bin` or `$HOME/go/bin` if the `GOPATH` is not set.
 
+### Unofficial Ubuntu PPA
+
+The `systemd` service running the relay with the default settings and limited allowed CPU loads can be also installed for most Debian/Ubuntu-based distributions from the dedicated [Ubuntu PPA](https://launchpad.net/~twdragon/+archive/ubuntu/ipfs):
+
+#### Latest Ubuntu (>= 20.04 LTS)
+```sh
+sudo add-apt-repository ppa:twdragon/ipfs
+sudo apt update
+sudo apt install libp2p-relay
+```
+
+#### Any Ubuntu version
+
+```sh
+sudo su
+echo 'deb https://ppa.launchpadcontent.net/twdragon/ipfs/ubuntu <<DISTRO>> main' >> /etc/apt/sources.list.d/ipfs
+echo 'deb-src https://ppa.launchpadcontent.net/twdragon/ipfs/ubuntu <<DISTRO>> main' >> /etc/apt/sources.list.d/ipfs
+exit
+sudo apt update
+sudo apt install libp2p-relay
+```
+where `<<DISTRO>>` is the codename of your Ubuntu distribution (for example, `jammy` for 22.04 LTS). During the first installation the package maintenance script may automatically ask you about which networking profile, CPU accounting model, and/or existing node configuration file you want to use.
+
+**NOTE**: this method also may work with any compatible Debian-based distro which has `libc6` inside, `systemd`, and APT as a package manager.
+
+The development of the Debian packaging pipeline lives in the [dedicated Github repository](https://github.com/twdragon/ipfs-debian-pkg).
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ for both protocol versions [v1](https://github.com/libp2p/specs/blob/master/rela
   - [Source](#from-source)
   - [Unofficial Ubuntu PPA](#unofficial-ubuntu-ppa)
   - [Development Builds](#development-builds)
-- [Identity file](#identity-file)
+- [Tips & Tricks](#tips)
+  - [Standalone service unit](#running-as-a-standalone-systemd-service)
+  - [Identity file](#identity-file)
+  - [Private swarms](#private-swarms)
 - [Configuration](#configuration)
   - [Minimal config file](#minimal-config-file)
   - [All configuration options](#all-configuration-options)
@@ -62,19 +65,21 @@ cd go-libp2p-relay-daemon
 go install ./...
 ```
 
-## Running as a standalone systemd service
+## Tips
+
+### Running as a standalone systemd service
 
 There is a service file and an associated launch script in [`etc`](./etc) subdirectory.
 These two scripts assume that you have installed as root [in your container].
 If your installation path differs, you should adjust them accordingly.
 
-## Identity File
+### Identity File
 
 The daemon creates and persists an identity in the first run, using `identity` as the file
 to store the private key for the identity.
 You can specify the identity file path with the `-identity` option.
 
-## Private Swarms
+### Private Swarms
 
 The daemon can be instantiated using a multicodec-encoded V1 Private Swarm Key using the `-swarmkey` argument.
 Simply provide a filepath to the PSK and the daemon will automatically configure itself to use this for connections.


### PR DESCRIPTION
- Added unofficial Ubuntu PPA installation instructions. The Debian packaging pipeline development lives [here](https://github.com/twdragon/ipfs-debian-pkg). The PPA homepage: https://launchpad.net/~twdragon/+archive/ubuntu/ipfs
- Minor fixes on README